### PR TITLE
Map Uint8 and Uint16 to CL_UNSIGNED_8/16 instead of CL_UNORM_8/16

### DIFF
--- a/include/gls_cl_image.hpp
+++ b/include/gls_cl_image.hpp
@@ -44,15 +44,18 @@ class cl_image : public basic_image<T> {
                       std::is_same<typename T::value_type, int32_t>::value);
 
         cl_channel_order order = T::channels == 1 ? CL_R : T::channels == 2 ? CL_RG : CL_RGBA;
-        cl_channel_type type = std::is_same<typename T::value_type, float>::value ? CL_FLOAT :
+        cl_channel_type type = std::is_same<typename T::value_type, float>::value ? CL_FLOAT
 #if USE_FP16_FLOATS && !(__APPLE__ && __x86_64__)
-                               std::is_same<typename T::value_type, gls::float16_t>::value ? CL_HALF_FLOAT
-                               :
+                               : std::is_same<typename T::value_type, gls::float16_t>::value ? CL_HALF_FLOAT
 #endif
-                            //    std::is_same<typename T::value_type, uint8_t>::value    ? CL_UNORM_INT8
-                               std::is_same<typename T::value_type, uint8_t>::value    ? CL_UNSIGNED_INT8
-                            //    : std::is_same<typename T::value_type, uint16_t>::value ? CL_UNORM_INT16
+
+#ifdef OPENCL_MAP_UINT_NORMED
+                               : std::is_same<typename T::value_type, uint8_t>::value  ? CL_UNORM_INT8
+                               : std::is_same<typename T::value_type, uint16_t>::value ? CL_UNORM_INT16
+#else
+                               : std::is_same<typename T::value_type, uint8_t>::value  ? CL_UNSIGNED_INT8
                                : std::is_same<typename T::value_type, uint16_t>::value ? CL_UNSIGNED_INT16
+#endif
                                : std::is_same<typename T::value_type, uint32_t>::value ? CL_UNSIGNED_INT32
                                : std::is_same<typename T::value_type, int8_t>::value   ? CL_SNORM_INT8
                                : std::is_same<typename T::value_type, int16_t>::value  ? CL_SNORM_INT16
@@ -64,21 +67,21 @@ class cl_image : public basic_image<T> {
 
 // Other Supported OpenCL mappings
 
-#define DECLARE_TYPE_FORMATS(data_type, channel_type)                      \
-template <>                                                                \
-inline cl::ImageFormat cl_image<data_type>::ImageFormat() {                \
-    return cl::ImageFormat(CL_R, channel_type);                            \
-}                                                                          \
-                                                                           \
-template <>                                                                \
-inline cl::ImageFormat cl_image<std::array<data_type, 2>>::ImageFormat() { \
-    return cl::ImageFormat(CL_RG, channel_type);                           \
-}                                                                          \
-                                                                           \
-template <>                                                                \
-inline cl::ImageFormat cl_image<std::array<data_type, 4>>::ImageFormat() { \
-    return cl::ImageFormat(CL_RGBA, channel_type);                         \
-}
+#define DECLARE_TYPE_FORMATS(data_type, channel_type)                          \
+    template <>                                                                \
+    inline cl::ImageFormat cl_image<data_type>::ImageFormat() {                \
+        return cl::ImageFormat(CL_R, channel_type);                            \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    inline cl::ImageFormat cl_image<std::array<data_type, 2>>::ImageFormat() { \
+        return cl::ImageFormat(CL_RG, channel_type);                           \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    inline cl::ImageFormat cl_image<std::array<data_type, 4>>::ImageFormat() { \
+        return cl::ImageFormat(CL_RGBA, channel_type);                         \
+    }
 
 DECLARE_TYPE_FORMATS(float, CL_FLOAT)
 

--- a/include/gls_cl_image.hpp
+++ b/include/gls_cl_image.hpp
@@ -49,8 +49,10 @@ class cl_image : public basic_image<T> {
                                std::is_same<typename T::value_type, gls::float16_t>::value ? CL_HALF_FLOAT
                                :
 #endif
-                               std::is_same<typename T::value_type, uint8_t>::value    ? CL_UNORM_INT8
-                               : std::is_same<typename T::value_type, uint16_t>::value ? CL_UNORM_INT16
+                            //    std::is_same<typename T::value_type, uint8_t>::value    ? CL_UNORM_INT8
+                               std::is_same<typename T::value_type, uint8_t>::value    ? CL_UNSIGNED_INT8
+                            //    : std::is_same<typename T::value_type, uint16_t>::value ? CL_UNORM_INT16
+                               : std::is_same<typename T::value_type, uint16_t>::value ? CL_UNSIGNED_INT16
                                : std::is_same<typename T::value_type, uint32_t>::value ? CL_UNSIGNED_INT32
                                : std::is_same<typename T::value_type, int8_t>::value   ? CL_SNORM_INT8
                                : std::is_same<typename T::value_type, int16_t>::value  ? CL_SNORM_INT16
@@ -84,8 +86,10 @@ DECLARE_TYPE_FORMATS(float, CL_FLOAT)
 DECLARE_TYPE_FORMATS(gls::float16_t, CL_HALF_FLOAT)
 #endif
 
-DECLARE_TYPE_FORMATS(uint8_t, CL_UNORM_INT8)
-DECLARE_TYPE_FORMATS(uint16_t, CL_UNORM_INT16)
+// DECLARE_TYPE_FORMATS(uint8_t, CL_UNORM_INT8)
+DECLARE_TYPE_FORMATS(uint8_t, CL_UNSIGNED_INT8)
+// DECLARE_TYPE_FORMATS(uint16_t, CL_UNORM_INT16)
+DECLARE_TYPE_FORMATS(uint16_t, CL_UNSIGNED_INT16)
 DECLARE_TYPE_FORMATS(uint32_t, CL_UNSIGNED_INT32)
 
 DECLARE_TYPE_FORMATS(int8_t, CL_SNORM_INT8)

--- a/include/gls_gpu_image.hpp
+++ b/include/gls_gpu_image.hpp
@@ -92,6 +92,8 @@ class platform_texture;
 class texture {
 public:
     enum channel_type {
+        UNSIGNED_INT8,
+        UNSIGNED_INT16,
         UNORM_INT8,
         UNORM_INT16,
         UNSIGNED_INT32,
@@ -111,10 +113,12 @@ public:
             switch (dataType) {
                 case UNORM_INT8:
                 case SNORM_INT8:
+                case UNSIGNED_INT8:
                     type_size = 1;
                     break;
                 case UNORM_INT16:
                 case SNORM_INT16:
+                case UNSIGNED_INT16:
                 case FLOAT16:
                     type_size = 2;
                     break;
@@ -171,8 +175,10 @@ inline texture::format texture::TextureFormat() {
 #if USE_FP16_FLOATS && !(__APPLE__ && __x86_64__)
                            : std::is_same<typename T::value_type, gls::float16_t>::value ? FLOAT16
 #endif
-                           : std::is_same<typename T::value_type, uint8_t>::value  ? UNORM_INT8
-                           : std::is_same<typename T::value_type, uint16_t>::value ? UNORM_INT16
+                        //    : std::is_same<typename T::value_type, uint8_t>::value  ? UNORM_INT8
+                           : std::is_same<typename T::value_type, uint8_t>::value  ? UNSIGNED_INT8
+                        //    : std::is_same<typename T::value_type, uint16_t>::value ? UNORM_INT16
+                           : std::is_same<typename T::value_type, uint16_t>::value ? UNSIGNED_INT16
                            : std::is_same<typename T::value_type, uint32_t>::value ? UNSIGNED_INT32
                            : std::is_same<typename T::value_type, int8_t>::value   ? SNORM_INT8
                            : std::is_same<typename T::value_type, int16_t>::value  ? SNORM_INT16
@@ -203,8 +209,10 @@ DECLARE_TYPE_FORMATS(float, FLOAT32)
 DECLARE_TYPE_FORMATS(float16_t, FLOAT16)
 #endif
 
-DECLARE_TYPE_FORMATS(uint8_t, UNORM_INT8)
-DECLARE_TYPE_FORMATS(uint16_t, UNORM_INT16)
+// DECLARE_TYPE_FORMATS(uint8_t, UNORM_INT8)
+DECLARE_TYPE_FORMATS(uint8_t, UNSIGNED_INT8)
+// DECLARE_TYPE_FORMATS(uint16_t, UNORM_INT16)
+DECLARE_TYPE_FORMATS(uint16_t, UNSIGNED_INT16)
 DECLARE_TYPE_FORMATS(uint32_t, UNSIGNED_INT32)
 
 DECLARE_TYPE_FORMATS(int8_t, SNORM_INT8)

--- a/include/gls_ocl_image.hpp
+++ b/include/gls_ocl_image.hpp
@@ -11,37 +11,29 @@
 #include <exception>
 #include <map>
 
-#include "gls_image.hpp"
-#include "gls_gpu_image.hpp"
 #include "gls_cl.hpp"
+#include "gls_gpu_image.hpp"
+#include "gls_image.hpp"
 
 namespace gls {
 
 class ocl_texture : public virtual platform_texture {
-protected:
+   protected:
     cl::Buffer _buffer;
     cl::Image2D _image;
 
-public:
-    cl::Image2D image() const {
-        return _image;
-    }
+   public:
+    cl::Image2D image() const { return _image; }
 
-    int texture_width() const override {
-        return (int) _image.getImageInfo<CL_IMAGE_WIDTH>();
-    }
+    int texture_width() const override { return (int)_image.getImageInfo<CL_IMAGE_WIDTH>(); }
 
-    int texture_height() const override {
-        return (int) _image.getImageInfo<CL_IMAGE_HEIGHT>();
-    }
+    int texture_height() const override { return (int)_image.getImageInfo<CL_IMAGE_HEIGHT>(); }
 
     int texture_stride() const override {
-        return (int) _image.getImageInfo<CL_IMAGE_ROW_PITCH>() / _image.getImageInfo<CL_IMAGE_ELEMENT_SIZE>();
+        return (int)_image.getImageInfo<CL_IMAGE_ROW_PITCH>() / _image.getImageInfo<CL_IMAGE_ELEMENT_SIZE>();
     }
 
-    int pixelSize() const override {
-        return (int) _image.getImageInfo<CL_IMAGE_ELEMENT_SIZE>();
-    }
+    int pixelSize() const override { return (int)_image.getImageInfo<CL_IMAGE_ELEMENT_SIZE>(); }
 
     static int pixelSize(const cl::ImageFormat& format);
 
@@ -52,13 +44,18 @@ public:
 
         cl_channel_order order = format.channels == 1 ? CL_R : format.channels == 2 ? CL_RG : CL_RGBA;
         cl_channel_type type = format.dataType == FLOAT32 ? CL_FLOAT
-    #if USE_FP16_FLOATS && !(__APPLE__ && __x86_64__)
+#if USE_FP16_FLOATS && !(__APPLE__ && __x86_64__)
                                : format.dataType == FLOAT16 ? CL_HALF_FLOAT
-    #endif
-                            //    : format.dataType == UNORM_INT8     ? CL_UNORM_INT8
-                               : format.dataType == UNSIGNED_INT8     ? CL_UNSIGNED_INT8
-                            //    : format.dataType == UNORM_INT16    ? CL_UNORM_INT16
-                               : format.dataType == UNSIGNED_INT16    ? CL_UNSIGNED_INT16
+#endif
+
+#ifdef OPENCL_MAP_UINT_NORMED
+                               : format.dataType == UNORM_INT8  ? CL_UNORM_INT8
+                               : format.dataType == UNORM_INT16 ? CL_UNORM_INT16
+
+#else
+                               : format.dataType == UNSIGNED_INT8  ? CL_UNSIGNED_INT8
+                               : format.dataType == UNSIGNED_INT16 ? CL_UNSIGNED_INT16
+#endif
                                : format.dataType == UNSIGNED_INT32 ? CL_UNSIGNED_INT32
                                : format.dataType == SNORM_INT8     ? CL_SNORM_INT8
                                : format.dataType == SNORM_INT16    ? CL_SNORM_INT16
@@ -79,7 +76,7 @@ public:
         cl::CommandQueue queue = cl::CommandQueue::getDefault();
         size_t buffer_size = pixelSize() * texture_stride() * texture_height();
         void* mapped_data = queue.enqueueMapBuffer(_buffer, true, CL_MAP_READ | CL_MAP_WRITE, 0, buffer_size);
-        return std::span<uint8_t>((uint8_t*) mapped_data, buffer_size);
+        return std::span<uint8_t>((uint8_t*)mapped_data, buffer_size);
     }
 
     void unmapTexture(void* ptr) const override {
@@ -87,25 +84,19 @@ public:
         queue.enqueueUnmapMemObject(ocl_texture::_buffer, ptr);
     }
 
-    virtual const class platform_texture* operator() () const override {
-        return this;
-    }
+    virtual const class platform_texture* operator()() const override { return this; }
 };
 
 class ocl_buffer : public platform_buffer {
     const cl::Buffer _buffer;
 
-public:
-    ocl_buffer(cl::Context context, size_t lenght, bool readOnly) :
-        _buffer(cl::Buffer(context, readOnly ? CL_MEM_READ_ONLY : CL_MEM_READ_WRITE, lenght)) { }
+   public:
+    ocl_buffer(cl::Context context, size_t lenght, bool readOnly)
+        : _buffer(cl::Buffer(context, readOnly ? CL_MEM_READ_ONLY : CL_MEM_READ_WRITE, lenght)) {}
 
-    cl::Buffer buffer() const {
-        return _buffer;
-    }
+    cl::Buffer buffer() const { return _buffer; }
 
-    virtual size_t bufferSize() const override {
-        return (int) _buffer.getInfo<CL_MEM_SIZE>();
-    }
+    virtual size_t bufferSize() const override { return (int)_buffer.getInfo<CL_MEM_SIZE>(); }
 
     virtual void* mapBuffer() const override {
         cl::CommandQueue queue = cl::CommandQueue::getDefault();
@@ -117,9 +108,7 @@ public:
         queue.enqueueUnmapMemObject(_buffer, ptr);
     }
 
-    virtual const class platform_buffer* operator() () const override {
-        return this;
-    }
+    virtual const class platform_buffer* operator()() const override { return this; }
 };
 
 }  // namespace gls

--- a/include/gls_ocl_image.hpp
+++ b/include/gls_ocl_image.hpp
@@ -55,8 +55,10 @@ public:
     #if USE_FP16_FLOATS && !(__APPLE__ && __x86_64__)
                                : format.dataType == FLOAT16 ? CL_HALF_FLOAT
     #endif
-                               : format.dataType == UNORM_INT8     ? CL_UNORM_INT8
-                               : format.dataType == UNORM_INT16    ? CL_UNORM_INT16
+                            //    : format.dataType == UNORM_INT8     ? CL_UNORM_INT8
+                               : format.dataType == UNSIGNED_INT8     ? CL_UNSIGNED_INT8
+                            //    : format.dataType == UNORM_INT16    ? CL_UNORM_INT16
+                               : format.dataType == UNSIGNED_INT16    ? CL_UNSIGNED_INT16
                                : format.dataType == UNSIGNED_INT32 ? CL_UNSIGNED_INT32
                                : format.dataType == SNORM_INT8     ? CL_SNORM_INT8
                                : format.dataType == SNORM_INT16    ? CL_SNORM_INT16


### PR DESCRIPTION
Potentially breaking change for GPU images that now maps 8/16 bit unsigned integer types to CL_UNSIGNED, rather than CL_UNORM.
Before, for a uint16 image with [0, 1023] values the kernel would give
```
read_image2f(...) // [0, 1] float, here effectively [0, 0.015] with 1023 max input
read_imageui(...) // Just always zero.
```

now it gives
```
read_image2f(...) // Unchanged [0.0, 1023.0] float value
read_imageui(...) // Unchanged [0, 1023] uint16 value
```

This might break older kernels for SURF or Denoising, but none of them are in use to my knowledge