### PR TITLE
Minor changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ BasedOnStyle: Google
 DerivePointerAlignment: false
 IndentWidth: 4
 ColumnLimit: 120
+BreakBeforeBraces: Allman

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ DerivedData/
 
 *.dylib
 
+.cache
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 
 project("glass_image")
 
+# This will make cmake generate compile_commands.json, used by clangd and other tools
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Options
 option(GLASS_IMAGE_BUILD_IMAGE_IO "Build with image I/O libraries." OFF)
 SET_PROPERTY(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE) # TODO: Needed for something?

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,7 +11,7 @@
             "displayName": "Android",
             "description": "Cross-compile to Android with Clang",
             "binaryDir": "${sourceDir}/build",
-            "toolchainFile": "/Users/manuel/Library/Android/sdk/ndk/28.0.12433566/build/cmake/android.toolchain.cmake",
+            "toolchainFile": "/Users/$env{USER}/Library/Android/sdk/ndk/28.0.12433566/build/cmake/android.toolchain.cmake",
             "cacheVariables": {
                 "ANDROID_ABI": "arm64-v8a",
                 "ANDROID_PLATFORM": "android-33",

--- a/include/gls_android_support.h
+++ b/include/gls_android_support.h
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <map>
 #include <span>
+#include <vector>
 
 namespace gls {
 


### PR DESCRIPTION
* Generalize NDK path to work for non Manuels
* Minor changes to play nicely with Clangd and other tools that rely on `build/compile_commands.json`
* Update `.clang-format`, to be same GlassLibrary
