### PR TITLE
Fix logging and run formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ from `cl_pipeline.cpp` illustrates how to use the `gls::cl_image` types in conju
                        input.getImage2D(), output->getImage2D());
             return 0;
         } catch (cl::Error& err) {
-            LOG_ERROR(TAG) << "Caught Exception: " << std::string(err.what())
+            gls::logging::LogError(TAG) << "Caught Exception: " << std::string(err.what())
                            << " - " << gls::clStatusToString(err.err())
                            << std::endl;
             return -1;

--- a/android/GlassImageTest/app/src/main/cpp/ShaderCompiler.cpp
+++ b/android/GlassImageTest/app/src/main/cpp/ShaderCompiler.cpp
@@ -25,45 +25,54 @@ static const char* TAG = "ShaderCompiler";
 
 extern "C" int __android_log_print(int prio, const char* tag, const char* fmt, ...) { return 0; }
 
-int main(int argc, const char* argv[]) {
-    if (argc > 1 && strcmp(argv[1], "-help") == 0) {
+int main(int argc, const char* argv[])
+{
+    if (argc > 1 && strcmp(argv[1], "-help") == 0)
+    {
         std::cout << "OpenCL Shader Compiler." << std::endl;
         std::cout << "Usage: cat shader.cl | " << argv[0] << " outfile" << std::endl;
         return 0;
     }
 
-//    // Read shader source from stdin
-//    std::stringbuf buffer;
-//    std::ostream os(&buffer);
-//    for (std::string line; std::getline(std::cin, line);) {
-//        os << line << std::endl;
-//    }
+    //    // Read shader source from stdin
+    //    std::stringbuf buffer;
+    //    std::ostream os(&buffer);
+    //    for (std::string line; std::getline(std::cin, line);) {
+    //        os << line << std::endl;
+    //    }
 
     std::ifstream t("file.txt");
     std::stringstream buffer;
     buffer << std::cin.rdbuf();
 
-    try {
+    try
+    {
         gls::OpenCLContext glsContext(/*shadersRootPath=*/"", /*quiet=*/true);
         auto context = glsContext.clContext();
 
         cl::Program program(buffer.str());
-        if (gls::OpenCLContext::buildProgram(program) != 0) {
+        if (gls::OpenCLContext::buildProgram(program) != 0)
+        {
             return -1;
         }
 
         std::vector<std::vector<unsigned char>> binaries;
         cl_int result = program.getInfo(CL_PROGRAM_BINARIES, &binaries);
-        if (result != CL_SUCCESS) {
-            LOG_ERROR(TAG) << "CL_PROGRAM_BINARIES returned: " << gls::clStatusToString(result) << std::endl;
+        if (result != CL_SUCCESS)
+        {
+            gls::logging::LogError(TAG) << "CL_PROGRAM_BINARIES returned: " << gls::clStatusToString(result)
+                                        << std::endl;
             return -1;
         }
 
         gls::OpenCLContext::saveBinaryFile(argc > 1 ? argv[1] : "binaryShader.o", binaries[0]);
 
         return 0;
-    } catch (cl::Error& err) {
-        LOG_ERROR(TAG) << "Caught Exception: " << err.what() << " - " << gls::clStatusToString(err.err()) << std::endl;
+    }
+    catch (cl::Error& err)
+    {
+        gls::logging::LogError(TAG) << "Caught Exception: " << err.what() << " - " << gls::clStatusToString(err.err())
+                                    << std::endl;
         return -1;
     }
 }


### PR DESCRIPTION
Fix logging example in readme.
Not sure if this version of ShaderCompiler is used, but it came up when I grepped for the `LOG_...` so I updated it